### PR TITLE
Adjust method signatures to match parent

### DIFF
--- a/syntax/button.php
+++ b/syntax/button.php
@@ -47,7 +47,7 @@
         /**
          * Handle the match
          */
-        function handle($match, $state, $pos, &$handler){
+        function handle($match, $state, $pos, Doku_Handler $handler){
 		
 	   global $USERINFO;
 	   global $ID;
@@ -84,7 +84,7 @@
         /**
          * Create output
          */
-        function render($mode, &$renderer, $data) {
+        function render($mode, Doku_Renderer $renderer, $data) {
 		
 	    global $USERINFO;
 	    global $INFO;

--- a/syntax/feed.php
+++ b/syntax/feed.php
@@ -47,7 +47,7 @@
         /**
          * Handle the match
          */
-        function handle($match, $state, $pos, &$handler){
+        function handle($match, $state, $pos, Doku_Handler $handler){
         
             $match=substr($match,11,-2);
 			if($match) {
@@ -75,7 +75,7 @@
         /**
          * Create output
          */
-        function render($mode, &$renderer, $data) {
+        function render($mode, Doku_Renderer $renderer, $data) {
 		if (empty($data)) return false;
 		    global $ID;
             if($mode == 'xhtml'){

--- a/syntax/item.php
+++ b/syntax/item.php
@@ -52,7 +52,7 @@
         /**
          * Handle the match
          */
-        function handle($match, $state, $pos, &$handler){
+        function handle($match, $state, $pos, Doku_Handler $handler){
         
         
             switch ($state) {
@@ -91,7 +91,7 @@
         /**
          * Create output
          */
-        function render($mode, &$renderer, $data) {
+        function render($mode, Doku_Renderer $renderer, $data) {
 		if (empty($data)) return false;
             if($mode == 'xhtml'){
                 list($state, $match) = $data;


### PR DESCRIPTION
Starting with PHP 7, classes that overide methods from their parent have to match their parent's method signature regarding type hints. Otherwise PHP will throw an error.

Your plugin seems not to match DokuWiki's method signatures causing it to fail under PHP7. This patch tries to fix that.

Please note that this patch and the resulting pull request were created using an automated tool. Something might have gone, wrong so please carefully check before merging.

If you think the code submitted is wrong, please feel free to close this PR and excuse the mess.