### PR TITLE
[PATCH] Add per-feed optional RSS TTL element to allow automatic refresh.

### DIFF
--- a/admin.php
+++ b/admin.php
@@ -233,19 +233,22 @@ class admin_plugin_news extends DokuWiki_Admin_Plugin {
 	 
 	 function generate($subfeed) {	
 		global $newsChannelTitle;
-        global $newsChannelDescription;	
+        global $newsChannelDescription;
+        global $newsChannelTtl;	
         $newsfeed_ini = DOKU_INC . 'lib/plugins/news/scripts/newsfeed.ini';
          
          if(file_exists($newsfeed_ini)) {
             $ini_array = parse_ini_file($newsfeed_ini, true);   
             $which = isset($ini_array[$subfeed]) ? $subfeed : 'default';
             $newsChannelTitle = $ini_array[$which]['title'];
-            $newsChannelDescription = $ini_array[$which]['description'] ;         
+            $newsChannelDescription = $ini_array[$which]['description'] ;
+            $newsChannelTtl = $ini_array[$which]['ttl'];         
         }
         else {
             $subfeed = "";
             $newsChannelDescription = $this->getConf('desc');
             $newsChannelTitle=$this->getConf('title');
+            $newsChannelTtl = $his->getConf('ttl');
         }
     
 		    $create_time = 0;

--- a/scripts/feedData.php
+++ b/scripts/feedData.php
@@ -14,6 +14,7 @@ class feedData {
 	function feedData($subfeed) {
 		global $newsChannelTitle;
 		global $newsChannelDescription;	
+		global $newsChannelTtl;
 
         $this->helper = plugin_load('helper', 'news');
          $this->helper->setSubFeed($subfeed) ;    
@@ -181,6 +182,12 @@ class feedData {
 		global $newsChannelDescription;
 		if(!$newsChannelDescription) return  'DokuWiki News Feed';
 		return $newsChannelDescription;
+	}
+	
+	function channel_ttl() {
+		global $newsChannelTtl;
+		if(!$newsChannelTtl) return  $this->ttl;
+		return $newsChannelTtl;
 	}
 }
 

--- a/scripts/newsfeed.php
+++ b/scripts/newsfeed.php
@@ -14,7 +14,8 @@ require_once DOKU_INC . 'lib/plugins/news/scripts/rss.php';
 $newsfeed_ini = DOKU_INC . 'lib/plugins/news/scripts/newsfeed.ini';
 global $conf;
 global $newsChannelTitle;
-global $newsChannelDescription;	
+global $newsChannelDescription;
+global $newsChannelTtl;	
 global $newsFeedURL,$INPUT;
 $newsFeedURL = "";
 $refresh=false;
@@ -55,6 +56,7 @@ else {
     $which = isset($ini_array[$title]) ? $title : 'default';
     $newsChannelTitle = $ini_array[$which]['title'];
     $newsChannelDescription = $ini_array[$which]['description'] ;
+    $newsChannelTtl = $ini_array[$which]['ttl'];
 }
 
 	if(isset($conf['plugin']['news'])) {
@@ -67,6 +69,9 @@ else {
 		}
 		if(!$newsChannelDescription && isset($conf['plugin']['news']['desc'])) {
 			$newsChannelDescription = $conf['plugin']['news']['desc'];
+		}
+		if(!$newsChannelTtl && isset($conf['plugin']['news']['ttl'])) {
+			$newsChannelTtl = $conf['plugin']['news']['ttl'];
 		}
 	 	if(isset($conf['plugin']['news']['url'])) {
 			$newsFeedURL = $conf['plugin']['news']['url'];			

--- a/scripts/rss.php
+++ b/scripts/rss.php
@@ -77,7 +77,8 @@ ITEM;
 	    $link = $this->news_feed_url();
 		}
     $title = $this->channel_title();
-	$desc = $this->channel_description();    
+	$desc = $this->channel_description();
+	$ttl = $this->channel_ttl();    
 return <<<HEAD
 <?xml version="1.0" encoding="utf-8"?>
 <rss version="2.0">
@@ -87,6 +88,7 @@ return <<<HEAD
 	<description>$desc</description>
 	<language>en-us</language>
 	<pubDate>$date</pubDate>
+	<ttl>$ttl</ttl>
 HEAD;
 
 	}


### PR DESCRIPTION
Hello!

The following patch adds a per-feed optional TTL setting [1] that will add the optional RSS TTL key to the generated XML files. This change will help issues with the XML files being cached as well as instruct automatic RSS updates when to refresh a feed.

After applying this patch the file "newsfeed.ini" can be configured with an extra TTL key, for instance:

```
[mynews]
title = "The Rabbit's Foot"
description = "Down the Rabbit Hole"
ttl = 60
```

The being that the resulting XML will have the TTL key in the "channel" section as per the specification:

```xml
<channel>
        <title>The Rabbit's Foot</title>
        <link>http://rabbit.org/</link>
        <description>Down the Rabbit Hole</description>
        <language>en-us</language>
        <pubDate>Sun, 03 Jul 2016 12:47:04 +0000</pubDate>
        <ttl>60</ttl>
```

If useful, please apply! :-)

Kind Regards,
Eva

[1] TTL optional parameter, http://www.rssboard.org/rss-specification