### PR TITLE
wiki media url regex fix

### DIFF
--- a/scripts/feedData.php
+++ b/scripts/feedData.php
@@ -60,8 +60,8 @@ class feedData {
 	
     function description() {
             $this->currentDataArray['item'] =
-                        preg_replace('#(href|src)\s*=\s*([\'\"])/.*?/#ms', "$1=$2" . $this->news_feed_url(), $this->currentDataArray['item']);
-
+                        // preg_replace('#(href|src)\s*=\s*([\'\"])/.*?/#ms', "$1=$2" . $this->news_feed_url(), $this->currentDataArray['item']);
+                        preg_replace('#(href|src)\s*=\s*([\'\"])/#ms', "$1=$2" . $this->news_feed_url(), $this->currentDataArray['item']);
                         return $this->currentDataArray['item'];
     }
 	


### PR DESCRIPTION
Feed in client wont return correct URL for links and media.
I found the issue in feedData.php in regex preg_replace.

Maybe is it a good idea to keep in mind, that fixed regex could not include all url form in dokuwiki, can't tell. For now, It just work fine with the fix.

(thks for the pull request help, it's my first of the kind)